### PR TITLE
get latest fetch every time request is made

### DIFF
--- a/fetch-npm-browserify.js
+++ b/fetch-npm-browserify.js
@@ -3,4 +3,11 @@
 //
 // Return that as the export for use in Webpack, Browserify etc.
 require('whatwg-fetch');
-module.exports = self.fetch.bind(self);
+
+var useCurrentGlobalFetch = function(url, options) {
+    /* LogRocket.init() runs in app code and replaces global fetch, so
+    at request time, always get the latest instance of fetch from window. -- @george */
+    return self.fetch.call(self, url, options);
+};
+
+module.exports = useCurrentGlobalFetch


### PR DESCRIPTION
This library code generally gets executed before our app code, and the LogRocket polyfill of fetch runs first in our app code. 
I think the best way to preserve our pattern of importing the fetch function from isomorphic-fetch and also keep the library agnostic of LogRocket (at least as far as the code itself) is to make it reference the latest global fetch every time a request is made instead of referencing global fetch once before the app code has had a chance to run.